### PR TITLE
Fix/remove custom import paths

### DIFF
--- a/src/apis/embeddings.ts
+++ b/src/apis/embeddings.ts
@@ -1,4 +1,4 @@
-import { APIResponseType, ApiClientInterface } from "portkey-ai/_types/generalTypes";
+import { APIResponseType, ApiClientInterface } from "../_types/generalTypes";
 import { ModelParams } from "../_types/portkeyConstructs";
 import { ApiResource } from "../apiResource";
 import { APIPromise, RequestOptions } from "../baseClient";

--- a/src/apis/generations.ts
+++ b/src/apis/generations.ts
@@ -1,4 +1,4 @@
-import { APIResponseType, ApiClientInterface } from "portkey-ai/_types/generalTypes";
+import { APIResponseType, ApiClientInterface } from "../_types/generalTypes";
 import { ModelParams } from "../_types/portkeyConstructs";
 import { ApiResource } from "../apiResource";
 import { APIPromise, RequestOptions } from "../baseClient";

--- a/src/apis/postMethod.ts
+++ b/src/apis/postMethod.ts
@@ -1,4 +1,4 @@
-import { APIResponseType, ApiClientInterface } from "portkey-ai/_types/generalTypes";
+import { APIResponseType, ApiClientInterface } from "../_types/generalTypes";
 import { ApiResource } from "../apiResource";
 import { APIPromise, RequestOptions } from "../baseClient";
 import { Stream } from "../streaming";

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -8,8 +8,9 @@ import { Stream, createResponseHeaders, safeJSON } from "./streaming";
 import { castToError, getPlatformProperties, parseBody } from "./utils";
 import { VERSION } from "./version";
 
+fetch
 const defaultHttpAgent: Agent = new KeepAliveAgent({ keepAlive: true, timeout: 5 * 60 * 1000 });
-export type Fetch = (url: RequestInfo, init?: RequestInit) => Promise<Response>;
+export type Fetch = (url: NodeJS.fetch.RequestInfo, init?: RequestInit) => Promise<Response>;
 
 export type HTTPMethod = "post" | "get" | "put" | "delete"
 
@@ -46,7 +47,7 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
     const contentType = response.headers.get("content-type");
     if (contentType?.includes("application/json")) {
         const headers = defaultParseHeaders(props)
-        const json = {
+                const json = {
             ...await response.json(),
             getHeaders: () => headers
         };

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -7,7 +7,6 @@ import { APIConnectionError, APIConnectionTimeoutError, APIError } from "./error
 import { Stream, createResponseHeaders, safeJSON } from "./streaming";
 import { castToError, getPlatformProperties, parseBody } from "./utils";
 import { VERSION } from "./version";
-
 fetch
 const defaultHttpAgent: Agent = new KeepAliveAgent({ keepAlive: true, timeout: 5 * 60 * 1000 });
 export type Fetch = (url: NodeJS.fetch.RequestInfo, init?: RequestInit) => Promise<Response>;
@@ -47,7 +46,7 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
     const contentType = response.headers.get("content-type");
     if (contentType?.includes("application/json")) {
         const headers = defaultParseHeaders(props)
-                const json = {
+        const json = {
             ...await response.json(),
             getHeaders: () => headers
         };

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -7,9 +7,9 @@ import { APIConnectionError, APIConnectionTimeoutError, APIError } from "./error
 import { Stream, createResponseHeaders, safeJSON } from "./streaming";
 import { castToError, getPlatformProperties, parseBody } from "./utils";
 import { VERSION } from "./version";
-fetch
+
 const defaultHttpAgent: Agent = new KeepAliveAgent({ keepAlive: true, timeout: 5 * 60 * 1000 });
-export type Fetch = (url: NodeJS.fetch.RequestInfo, init?: RequestInit) => Promise<Response>;
+export type Fetch = (url: RequestInfo, init?: RequestInit) => Promise<Response>;
 
 export type HTTPMethod = "post" | "get" | "put" | "delete"
 

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -9,7 +9,7 @@ import { castToError, getPlatformProperties, parseBody } from "./utils";
 import { VERSION } from "./version";
 fetch
 const defaultHttpAgent: Agent = new KeepAliveAgent({ keepAlive: true, timeout: 5 * 60 * 1000 });
-export type Fetch = (url: NodeJS.fetch.RequestInfo, init?: RequestInit) => Promise<Response>;
+export type Fetch = (url: string, init?: RequestInit) => Promise<Response>;
 
 export type HTTPMethod = "post" | "get" | "put" | "delete"
 


### PR DESCRIPTION
**Title:** remove custom import paths

**Description:**
- Replace module imports in `src/apis/postMethod.ts`, `src/apis/embeddings.ts`, `src/apis/generations.ts`
- Remove use of NodeJS.fetch namespace as its removed in recent versions of @types/node

**Motivation:**
- To replace module imports: https://github.com/microsoft/TypeScript/issues/10866
- To avoid build errors due to fetch namespace unavailability: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67341

**Related Issues:**
- Closes #21 
- Closes #22 