### PR TITLE
chore: remove deprecated interfaces

### DIFF
--- a/src/_types/portkeyConstructs.ts
+++ b/src/_types/portkeyConstructs.ts
@@ -36,7 +36,3 @@ export interface Message {
     role: string
     content: string
 }
-
-export const ModelParamsList = [
-	"model", "suffix", "max_tokens", "temperature", "top_k", "top_p", "n", "stop_sequences", "timeout", "functions", "function_call", "logprobs", "echo", "stop", "presence_penalty", "frequency_penalty", "best_of", "logit_bias", "user", "organization"
-]

--- a/src/_types/portkeyConstructs.ts
+++ b/src/_types/portkeyConstructs.ts
@@ -1,35 +1,13 @@
-
-
-
 export interface RetrySettings {
     attempts: number;
     on_status_codes: Array<number>
 }
-
-export interface Constructs {
-    provider?: string;
-    api_key?: string;
-    virtual_key?: string;
-    cache?: boolean;
-    cache_age?: number;
-    cache_status?: string;
-    cache_force_refresh?: boolean;
-    trace_id?: string;
-    metadata?: Record<string, any>;
-    weight?: number;
-    retry?: RetrySettings;
-    deployment_id?: string;
-    resource_name?: string;
-    api_version?: string;
-}
-
 
 export interface Function {
     name: string;
     description: string;
     parameters: string;
 }
-
 
 export interface ModelParams {
     model?: string;
@@ -54,20 +32,10 @@ export interface ModelParams {
     organization?: string;
 }
 
-export interface ConversationInput {
-    prompt?: string;
-    messages?: Array<Message>
-}
-
 export interface Message {
     role: string
     content: string
 }
-
-export interface LLMOptions extends Constructs, ConversationInput, ModelParams {
-    override_params?: Record<string, any>
-}
-
 
 export const ModelParamsList = [
 	"model", "suffix", "max_tokens", "temperature", "top_k", "top_p", "n", "stop_sequences", "timeout", "functions", "function_call", "logprobs", "echo", "stop", "presence_penalty", "frequency_penalty", "best_of", "logit_bias", "user", "organization"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
-import * as Types from "./_types/portkeyConstructs";
 import * as apis from "./apis";
 import * as client from "./client";
 import * as consts from "./constants";
 
 export import Portkey = client.Portkey;
-export import LLMOptions = Types.LLMOptions;
 export import PORTKEY_GATEWAY_URL = consts.PORTKEY_GATEWAY_URL
 export import createHeaders = apis.createHeaders
 


### PR DESCRIPTION
**Title:**  remove deprecated interfaces

**Description:**
- Remove these interface: LLMOptions, Constructs, ConversationInput as they are no longer valid

**Motivation:**
- To remove unnecessary code

**Related Issues:**
- Closes #25 