### PR TITLE
fix: cacheForceRefresh and empty headers fix

### DIFF
--- a/src/_types/generalTypes.ts
+++ b/src/_types/generalTypes.ts
@@ -9,6 +9,7 @@ export interface ApiClientInterface {
     traceID?: string | null | undefined;
     metadata?: Record<string, unknown> | null | undefined;
     Authorization?: string | null | undefined;
+    cacheForceRefresh?: boolean | null | undefined;
 }
 
 export interface APIResponseType {

--- a/src/apis/createHeaders.ts
+++ b/src/apis/createHeaders.ts
@@ -4,7 +4,10 @@ export const createHeaders = (config: Record<string, any>): Record<string, strin
 	const headers: Record<string, string> = {}
 
 	for (let k in config) {
-		let v = config[k]
+		let v = config[k];
+
+		if (isEmpty(v)) continue;
+
 		// convert to snakecase
 		if (k.toLocaleLowerCase() === "authorization") {
 			headers[k.toLowerCase()] = v || ""

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -119,10 +119,10 @@ export abstract class ApiClient {
     responseHeaders: Record<string, string>
 
     private fetch: Fetch;
-    constructor({ apiKey, baseURL, config, virtualKey, traceID, metadata, provider, Authorization }: ApiClientInterface) {
+    constructor({ apiKey, baseURL, config, virtualKey, traceID, metadata, provider, Authorization, cacheForceRefresh }: ApiClientInterface) {
         this.apiKey = apiKey ?? "";
         this.baseURL = baseURL ?? "";
-        this.customHeaders = createHeaders({ apiKey, config, virtualKey, traceID, metadata, provider, Authorization })
+        this.customHeaders = createHeaders({ apiKey, config, virtualKey, traceID, metadata, provider, Authorization, cacheForceRefresh })
         this.fetch = fetch;
         this.responseHeaders = {}
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,7 @@ export class Portkey extends ApiClient {
 	traceID: string | null | undefined;
 	metadata: Record<string, unknown> | null | undefined;
 	Authorization?: string;
+	cacheForceRefresh?: boolean | null | undefined;
 	constructor({
 		apiKey = readEnv("PORTKEY_API_KEY") ?? null,
 		baseURL = readEnv("PORTKEY_BASE_URL") ?? null,
@@ -23,8 +24,8 @@ export class Portkey extends ApiClient {
 		provider,
 		traceID,
 		metadata,
-		Authorization
-
+		Authorization,
+		cacheForceRefresh
 	}: ApiClientInterface) {
 
 		super({
@@ -35,7 +36,8 @@ export class Portkey extends ApiClient {
 			provider,
 			traceID,
 			metadata,
-			Authorization
+			Authorization,
+			cacheForceRefresh
 		});
 		this.apiKey = apiKey;
 		if (!this.apiKey) {
@@ -47,6 +49,7 @@ export class Portkey extends ApiClient {
 		this.provider = provider
 		this.traceID = traceID
 		this.metadata = metadata
+		this.cacheForceRefresh = cacheForceRefresh;
 	}
 
 	completions: API.Completions = new API.Completions(this);


### PR DESCRIPTION
**Title:** cacheForceRefresh and empty headers fix

**Description:**
- Add an isEmpty check before setting header values to avoid empty headers in request.
- Accept cacheForceRefresh as a parm

**Motivation:**
- To fix errors and support latest signature

**Related Issues:**
- Fixes #33 
- Fixes #32 