### PR TITLE
hotfix: openai version lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   "dependencies": {
     "agentkeepalive": "^4.5.0",
     "dotenv": "^16.3.1",
-    "openai": "^4.28.4"
+    "openai": "4.36.0"
   }
 }


### PR DESCRIPTION
**Title:** OpenAI Version lock

**Description:**
- To support OpenAI upto a particular version
- beta.assistants.file .message.files etc support issue

**Related Issues:**
#57 