### PR TITLE
vercel response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.DS_Store

--- a/src/apis/chatCompletions.ts
+++ b/src/apis/chatCompletions.ts
@@ -85,8 +85,8 @@ interface FunctionCall {
   }
 
 interface Message {
-    role?: string
-    content?: string
+    role?: string;
+    content?: string;
     function_call?: FunctionCall;
     tool_calls?: Array<ToolCall>;
 }

--- a/src/apis/chatCompletions.ts
+++ b/src/apis/chatCompletions.ts
@@ -67,15 +67,34 @@ interface Usage {
     total_tokens?: number;
 }
 
+interface FunctionType {
+    arguments?: string;
+    name?: string;
+  }
+
+interface ToolCall {
+    index?: number;
+    id?: string;
+    function?: FunctionType;
+    type?: 'function';
+  }
+
+interface FunctionCall {
+    arguments?: string;
+    name?: string;
+  }
+
 interface Message {
-    role: string
-    content: string
+    role?: string
+    content?: string
+    function_call?: FunctionCall;
+    tool_calls?: Array<ToolCall>;
 }
 
 interface Choices {
     index?: number;
     message?: Message;
-    delta?: Message
+    delta?: Message;
     finish_reason?: string;
 }
 

--- a/src/apis/chatCompletions.ts
+++ b/src/apis/chatCompletions.ts
@@ -86,8 +86,8 @@ interface FunctionCall {
   }
 
 interface Message {
-    role?: string;
-    content?: string;
+    role: string;
+    content: string | null;
     function_call?: FunctionCall;
     tool_calls?: Array<ToolCall>;
 }


### PR DESCRIPTION
**Title:** Vercel response type for Chat completion stream

**Description:**
- Added the missing field for the chat completion response type
- function_call and tool_call were missing 
- fields added as optional fields 
- nested under chatCompletion -> choices -> delta 

**Motivation:**
Issue reported by a user on Discord: https://discord.com/channels/1143393887742861333/1143402158394454016/1242841759013404815

**Related Issues:**
Closes #80 