### PR TITLE
Remove unused locals (to fix Typescript noUnusedLocals problem)

### DIFF
--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -187,7 +187,7 @@ export abstract class ApiClient {
 
     buildRequest(opts: FinalRequestOptions): { req: RequestInit, url: string } {
         const url = new URL(this.baseURL + opts.path!)
-        const { method, path, query, headers: headers = {}, body } = opts;
+        const { method, body } = opts;
         const reqHeaders: Record<string, string> = {
             ...this.defaultHeaders(), ...this.customHeaders,
         };

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -66,11 +66,9 @@ export class Stream<Item> implements AsyncIterable<Item> {
 	}
 
 	async *[Symbol.asyncIterator](): AsyncIterator<Item, any, undefined> {
-		let done = false;
 		try {
 			for await (const sse of this.iterMessages()) {
 				if (sse.data.startsWith('[DONE]')) {
-					done = true;
 					continue;
 				}
 				if (sse.event === null) {
@@ -91,7 +89,6 @@ export class Stream<Item> implements AsyncIterable<Item> {
 					throw APIError
 				}
 			}
-			done = true;
 		} catch (e) {
 			if (e instanceof Error && e.name === "AbortError") return;
 			throw e;


### PR DESCRIPTION
**Title:** Remove unused locals (to fix Typescript noUnusedLocals problem)

**Description:**
This PR removes some unused variables that cause TS to complain

**Motivation:**
For some reason I can't explain I'm getting these Typescript issues after having installed portkey. I have `compilerOptions.skipLibCheck = true` and `exclude: ["node_modules"]` in my tsconfig but it still happens. Even Claude Sonnet and GPT-4o are confused about why this is happening. Anyway, I figured I might as well contribute and improve the library rather than just applying a local patch

```
../node_modules/portkey-ai/dist/src/baseClient.ts:190:25 - error TS6133: 'path' is declared but its value is never read.

190         const { method, path, query, headers: headers = {}, body } = opts;
                            ~~~~

../node_modules/portkey-ai/dist/src/baseClient.ts:190:31 - error TS6133: 'query' is declared but its value is never read.

190         const { method, path, query, headers: headers = {}, body } = opts;
                                  ~~~~~

../node_modules/portkey-ai/dist/src/baseClient.ts:190:47 - error TS6133: 'headers' is declared but its value is never read.

190         const { method, path, query, headers: headers = {}, body } = opts;
                                                  ~~~~~~~

../node_modules/portkey-ai/dist/src/streaming.ts:69:7 - error TS6133: 'done' is declared but its value is never read.

69   let done = false;
         ~~~~

[9:27:41 PM] Found 4 errors. Watching for file changes.

```
