### PR TITLE
Making API Key optional is self hosted gateway

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,9 +2,8 @@ import { ApiClientInterface } from './_types/generalTypes';
 import * as API from './apis';
 import { PostBodyParams, PostResponse } from './apis/postMethod';
 import { ApiClient, APIPromise, RequestOptions } from './baseClient';
-import { LOCAL_BASE_URL, MISSING_API_KEY_ERROR_MESSAGE, PORTKEY_BASE_URL } from './constants';
 import { Stream } from './streaming';
-import { castToError, readEnv } from './utils';
+import { readEnv, setApiKey, setBaseURL } from './utils';
 
 export class Portkey extends ApiClient {
   declare apiKey: string | null;
@@ -107,17 +106,8 @@ export class Portkey extends ApiClient {
       anthropicVersion,
       mistralFimCompletion,
     });
-    console.log("baseURL", baseURL);
-    if(!baseURL && !apiKey){
-      console.log("no base url and no api key");
-      baseURL = LOCAL_BASE_URL+'/v1';
-    }
-    this.baseURL = baseURL || PORTKEY_BASE_URL;
-    console.log("baseURL222", baseURL);
-    this.apiKey = apiKey;
-    if (this.baseURL === PORTKEY_BASE_URL && !this.apiKey) {
-      throw castToError(MISSING_API_KEY_ERROR_MESSAGE);
-    }
+    this.baseURL = setBaseURL(baseURL, apiKey);
+    this.apiKey = setApiKey(this.baseURL, apiKey);
     this.virtualKey = virtualKey || null;
     this.config = config || null;
     this.provider = provider;

--- a/src/client.ts
+++ b/src/client.ts
@@ -108,13 +108,13 @@ export class Portkey extends ApiClient {
       mistralFimCompletion,
     });
 
+    this.baseURL = baseURL || PORTKEY_BASE_URL;
     this.apiKey = apiKey;
-    if (!this.apiKey) {
+    if (this.baseURL === PORTKEY_BASE_URL && !this.apiKey) {
       throw castToError(MISSING_API_KEY_ERROR_MESSAGE);
     }
     this.virtualKey = virtualKey || null;
     this.config = config || null;
-    this.baseURL = baseURL || PORTKEY_BASE_URL;
     this.provider = provider;
     this.traceID = traceID;
     this.metadata = metadata;

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,7 @@ import { ApiClientInterface } from './_types/generalTypes';
 import * as API from './apis';
 import { PostBodyParams, PostResponse } from './apis/postMethod';
 import { ApiClient, APIPromise, RequestOptions } from './baseClient';
-import { MISSING_API_KEY_ERROR_MESSAGE, PORTKEY_BASE_URL } from './constants';
+import { LOCAL_BASE_URL, MISSING_API_KEY_ERROR_MESSAGE, PORTKEY_BASE_URL } from './constants';
 import { Stream } from './streaming';
 import { castToError, readEnv } from './utils';
 
@@ -107,8 +107,13 @@ export class Portkey extends ApiClient {
       anthropicVersion,
       mistralFimCompletion,
     });
-
+    console.log("baseURL", baseURL);
+    if(!baseURL && !apiKey){
+      console.log("no base url and no api key");
+      baseURL = LOCAL_BASE_URL+'/v1';
+    }
     this.baseURL = baseURL || PORTKEY_BASE_URL;
+    console.log("baseURL222", baseURL);
     this.apiKey = apiKey;
     if (this.baseURL === PORTKEY_BASE_URL && !this.apiKey) {
       throw castToError(MISSING_API_KEY_ERROR_MESSAGE);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,16 +22,16 @@ type "ModesLiteral | Modes | None"
 
 export const LOCALHOST_CONNECTION_ERROR = `Could not instantiate the Portkey client. \
 You can either add a valid 'apiKey' parameter (from https://app.portkey.ai/api-keys) \
-or set the 'baseURL' parameter to your AI Gateway's instance's URL.`
+or set the 'baseURL' parameter to your AI Gateway's instance's URL.`;
 
 export const CUSTOM_HOST_CONNECTION_ERROR = `We could not connect to the AI Gateway's instance. \
-Please check the 'baseURL' parameter in the Portkey client.`
+Please check the 'baseURL' parameter in the Portkey client.`;
 
 export const DEFAULT_MAX_RETRIES = 2;
 export const DEFAULT_TIMEOUT = 60;
 export const PORTKEY_HEADER_PREFIX = 'x-portkey-';
 export const PORTKEY_BASE_URL = 'https://api.portkey.ai/v1';
-export const LOCAL_BASE_URL = 'http://localhost:8787';
+export const LOCAL_BASE_URL = 'http://localhost:8787/v1';
 export const PORTKEY_GATEWAY_URL = PORTKEY_BASE_URL;
 
 export const PORTKEY_API_KEY_ENV = 'PORTKEY_API_KEY';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,9 @@
-export const MISSING_API_KEY_ERROR_MESSAGE = `No API key found for Portkey.
-Please set either the PORTKEY_API_KEY environment variable or \
-pass the api_key in the to initialization of Portkey.
-API keys can be found or created at Portkey Dashboard \
+export const MISSING_API_KEY_ERROR_MESSAGE = `Portkey API Key Not Found
+Resolution: \
 
-Here's how you get it:
-1. Visit https://app.portkey.ai/
-1. Click on your profile icon on the top left
-2. From the dropdown menu, click on "Copy API Key"
+1. Get your Portkey API key from https://app.portkey.ai/api-keys \
+
+2. Pass it while instantiating the Portkey client with apiKey param, or set it as an environment variable with export PORTKEY_API_KEY=YOUR_API_KEY
 `;
 
 export const MISSING_BASE_URL = `No Base url provided. Please provide a valid base url.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,10 +20,18 @@ export const INVALID_PORTKEY_MODE = `Argument of type '{}' cannot be assigned to
 type "ModesLiteral | Modes | None"
 `;
 
+export const LOCALHOST_CONNECTION_ERROR = `Could not instantiate the Portkey client. \
+You can either add a valid 'apiKey' parameter (from https://app.portkey.ai/api-keys) \
+or set the 'baseURL' parameter to your AI Gateway's instance's URL.`
+
+export const CUSTOM_HOST_CONNECTION_ERROR = `We could not connect to the AI Gateway's instance. \
+Please check the 'baseURL' parameter in the Portkey client.`
+
 export const DEFAULT_MAX_RETRIES = 2;
 export const DEFAULT_TIMEOUT = 60;
 export const PORTKEY_HEADER_PREFIX = 'x-portkey-';
 export const PORTKEY_BASE_URL = 'https://api.portkey.ai/v1';
+export const LOCAL_BASE_URL = 'http://localhost:8787';
 export const PORTKEY_GATEWAY_URL = PORTKEY_BASE_URL;
 
 export const PORTKEY_API_KEY_ENV = 'PORTKEY_API_KEY';

--- a/src/error.ts
+++ b/src/error.ts
@@ -94,7 +94,16 @@ export class APIConnectionError extends APIError {
     message?: string;
     cause?: Error | undefined;
   }) {
-    super(undefined, undefined, message || 'Connection error.', undefined);
+    const LOCALHOST_CONNECTION_ERROR = `Could not instantiate the Portkey client. 
+    You can either add a valid 'apiKey' parameter (from https://app.portkey.ai/api-keys)
+    or check the 'baseURL' parameter in the Portkey client,
+    for your AI Gateway's instance's URL.`;
+    super(
+      undefined,
+      undefined,
+      message || LOCALHOST_CONNECTION_ERROR,
+      undefined
+    );
     // in some environments the 'cause' property is already declared
     // @ts-ignore
     if (cause) this.cause = cause;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,10 @@
-import { OPEN_AI_API_KEY, PORTKEY_HEADER_PREFIX } from './constants';
+import {
+  LOCAL_BASE_URL,
+  MISSING_API_KEY_ERROR_MESSAGE,
+  OPEN_AI_API_KEY,
+  PORTKEY_BASE_URL,
+  PORTKEY_HEADER_PREFIX,
+} from './constants';
 import { createResponseHeaders } from './streaming';
 import OpenAI from 'openai';
 import type { Portkey } from './index';
@@ -166,4 +172,20 @@ export function toQueryParams(
     .join('&');
 
   return queryParams ? `?${queryParams}` : '';
+}
+
+export function setBaseURL(baseURL: any, apiKey: any) {
+  if (baseURL) {
+    return baseURL;
+  }
+  return apiKey ? PORTKEY_BASE_URL : LOCAL_BASE_URL;
+}
+
+export function setApiKey(baseURL: any, apiKey: any) {
+  if (apiKey) {
+    return apiKey;
+  }
+  if (baseURL === PORTKEY_BASE_URL && !apiKey) {
+    throw castToError(MISSING_API_KEY_ERROR_MESSAGE);
+  }
 }


### PR DESCRIPTION
**Title:** Making API Key optional is self hosted gateway

**Description:**
- Checking if it is not PORTKEY_BASE_URL then keep apiKey optional
- If apiKey not present, then set baseURL as localhost

**Related Issues:**
Fixes #131 