### PR TITLE
Spread Operator Issue: #130

### DIFF
--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -57,7 +57,7 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
   if (contentType?.includes('application/json')) {
     const headers = defaultParseHeaders(props);
     const json = {
-      ...(await response.json()),
+      ...(await response.json() as any),
       getHeaders: () => headers,
     };
 


### PR DESCRIPTION
**Title:** Adding type `any`

**Description:**
- TS issue resolved by adding type `any`
- Since it returns Promise<any> hence we send it `as any`

**Motivation:**
Issue reported by User

**Related Issues:**
Closes: #130 