### PR TITLE
fix: forwardHeaders logic

### DIFF
--- a/src/_types/generalTypes.ts
+++ b/src/_types/generalTypes.ts
@@ -33,6 +33,7 @@ export interface ApiClientInterface {
   anthropicBeta?: string | null | undefined;
   anthropicVersion?: string | null | undefined;
   mistralFimCompletion?: string | null | undefined;
+  [key: string]: any;
 }
 
 export interface APIResponseType {

--- a/src/apis/createHeaders.ts
+++ b/src/apis/createHeaders.ts
@@ -4,6 +4,16 @@ export const createHeaders = (
   config: Record<string, any>
 ): Record<string, string> => {
   const headers: Record<string, string> = {};
+  let forwardHeaders: string[] = [];
+
+  if (config['forwardHeaders']) {
+    // logic to convert forwardHeaders values to kebab-case
+    forwardHeaders = config['forwardHeaders'].map((header: string) => {
+      return header
+        .replace('ID', 'Id')
+        .replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+    });
+  }
 
   for (let k in config) {
     let v = config[k];
@@ -31,7 +41,11 @@ export const createHeaders = (
     if (!isEmpty(v) && typeof v == 'object') {
       v = JSON.stringify(v);
     }
-    headers[getPortkeyHeader(k)] = v || '';
+    if (forwardHeaders && forwardHeaders.includes(k)) {
+      headers[k] = v || '';
+    } else {
+      headers[getPortkeyHeader(k)] = v || '';
+    }
   }
   return headers;
 };

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -170,6 +170,7 @@ export abstract class ApiClient {
     anthropicBeta,
     anthropicVersion,
     mistralFimCompletion,
+    ...rest
   }: ApiClientInterface) {
     this.apiKey = apiKey ?? '';
     this.baseURL = baseURL ?? '';
@@ -205,6 +206,7 @@ export abstract class ApiClient {
       anthropicVersion,
       mistralFimCompletion,
       anthropicBeta,
+      ...rest,
     });
     this.portkeyHeaders = this.defaultHeaders();
     this.fetch = fetch;

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,6 +71,7 @@ export class Portkey extends ApiClient {
     anthropicBeta,
     anthropicVersion,
     mistralFimCompletion,
+    ...rest
   }: ApiClientInterface) {
     super({
       apiKey,
@@ -105,6 +106,7 @@ export class Portkey extends ApiClient {
       anthropicBeta,
       anthropicVersion,
       mistralFimCompletion,
+      ...rest,
     });
     this.baseURL = setBaseURL(baseURL, apiKey);
     this.apiKey = setApiKey(this.baseURL, apiKey);


### PR DESCRIPTION
**Title:** forwardHeaders Logic

**Description:**
- Logic to check for forward headers array and not prefix x-portkey to those headers
- Provision to accept any extra values in the initialization 

**Motivation:**
Issue reported by user

**Related Issues:**
Closes: #160 