### PR TITLE
Retry requests

### DIFF
--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -261,7 +261,7 @@ export abstract class ApiClient {
     return APIError.generate(status, errorResponse, message, headers);
   }
 
-  private shouldRetry(response: Response): boolean {
+  _shouldRetry(response: Response): boolean {
     const retryStatusCode = response.status;
     const retryTraceId = response.headers.get('x-portkey-trace-id');
     const retryRequestId = response.headers.get('x-portkey-request-id');
@@ -306,7 +306,7 @@ export abstract class ApiClient {
     }
     this.responseHeaders = createResponseHeaders(response.headers);
     if (!response.ok) {
-      if (retryCount < this.maxRetries && this.shouldRetry(response)) {
+      if (retryCount < this.maxRetries && this._shouldRetry(response)) {
         return this.request(opts, retryCount + 1);
       }
       const errText = await response.text().catch(() => 'Unknown');

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -11,6 +11,7 @@ import {
   APIConnectionError,
   APIConnectionTimeoutError,
   APIError,
+  APIUserAbortError,
 } from './error';
 import { Stream, createResponseHeaders, safeJSON } from './streaming';
 import { castToError, getPlatformProperties, parseBody } from './utils';
@@ -37,6 +38,7 @@ export type RequestOptions = {
   headers?: Headers | undefined;
   httpAgent?: Agent;
   stream?: boolean | undefined;
+  signal?: AbortSignal | undefined | null;
 };
 
 type APIResponseProps = {
@@ -135,6 +137,7 @@ export abstract class ApiClient {
   customHeaders: Record<string, string>;
   responseHeaders: Record<string, string>;
   portkeyHeaders: Record<string, string>;
+  maxRetries = 1;
 
   private fetch: Fetch;
   constructor({
@@ -258,13 +261,42 @@ export abstract class ApiClient {
     return APIError.generate(status, errorResponse, message, headers);
   }
 
-  async request(opts: FinalRequestOptions): Promise<APIResponseProps> {
+  private shouldRetry(response: Response): boolean {
+    const retryStatusCode = response.status;
+    const retryTraceId = response.headers.get('x-portkey-trace-id');
+    const retryRequestId = response.headers.get('x-portkey-request-id');
+    const retryGatewayException = response.headers.get(
+      'x-portkey-gateway-exception'
+    );
+
+    if (
+      retryStatusCode < 500 ||
+      retryTraceId ||
+      retryRequestId ||
+      retryGatewayException
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  async request(
+    opts: FinalRequestOptions,
+    retryCount = 0
+  ): Promise<APIResponseProps> {
     // Build the request.
     const { req, url } = this.buildRequest(opts);
     // Make the call to rubeus.
     const response = await this.fetch(url, req).catch(castToError);
     // Parse the response and check for errors.
     if (response instanceof Error) {
+      if (opts.signal?.aborted) {
+        throw new APIUserAbortError();
+      }
+      if (retryCount < this.maxRetries) {
+        return this.request(opts, retryCount + 1);
+      }
       if (response.name === 'AbortError') {
         throw new APIConnectionTimeoutError({
           message: `${response.message} \n STACK: ${response.stack}`,
@@ -274,6 +306,9 @@ export abstract class ApiClient {
     }
     this.responseHeaders = createResponseHeaders(response.headers);
     if (!response.ok) {
+      if (retryCount < this.maxRetries && this.shouldRetry(response)) {
+        return this.request(opts, retryCount + 1);
+      }
       const errText = await response.text().catch(() => 'Unknown');
       const errJSON = safeJSON(errText);
       const errMessage = errJSON ? undefined : errText;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,6 +152,15 @@ export function initOpenAIClient(client: Portkey) {
     baseURL: client.baseURL,
     defaultHeaders: defaultHeadersBuilder(client),
     maxRetries: 0,
+    fetch: async (url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      const response = await fetch(url, init);
+      if (!response.ok && client._shouldRetry(response)) {
+        const response = await fetch(url, init);
+        return response;
+      } else {
+        return response;
+      }
+    },
   });
 }
 export function toQueryParams(


### PR DESCRIPTION
**Title:** retry request in case of failure

**Description:**
- max retry set as 1 
- retry portkey endpoints failure
- retry for openai endpoints failure

**Motivation:**
Handle the cloudflare error

**Related Issues:**
Fixes: #165 