### PR TITLE
Fix: SDK in browser

### DIFF
--- a/src/_types/generalTypes.ts
+++ b/src/_types/generalTypes.ts
@@ -33,6 +33,7 @@ export interface ApiClientInterface {
   anthropicBeta?: string | null | undefined;
   anthropicVersion?: string | null | undefined;
   mistralFimCompletion?: string | null | undefined;
+  dangerouslyAllowBrowser?: boolean | null | undefined;
   [key: string]: any;
 }
 

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -184,6 +184,7 @@ export abstract class ApiClient {
     anthropicBeta,
     anthropicVersion,
     mistralFimCompletion,
+    dangerouslyAllowBrowser,
     ...rest
   }: ApiClientInterface) {
     this.apiKey = apiKey ?? '';
@@ -220,6 +221,7 @@ export abstract class ApiClient {
       anthropicVersion,
       mistralFimCompletion,
       anthropicBeta,
+      dangerouslyAllowBrowser,
       ...rest,
     });
     this.portkeyHeaders = this.defaultHeaders();

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -310,8 +310,9 @@ export abstract class ApiClient {
       ...this.customHeaders,
     };
 
-    const agentConfig = typeof window === 'undefined' ? { agent: defaultHttpAgent } : {};
-  
+    const agentConfig =
+      typeof window === 'undefined' ? { agent: defaultHttpAgent } : {};
+
     const req: RequestInit = {
       method,
       headers: reqHeaders,

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -21,7 +21,6 @@ const defaultHttpAgent: Agent = new KeepAliveAgent({
   timeout: 5 * 60 * 1000,
 });
 
-// Add this helper function at the top level
 function getFetch(): Fetch {
   if (typeof window !== 'undefined' && window.fetch) {
     return window.fetch.bind(window);

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -15,11 +15,25 @@ import {
 import { Stream, createResponseHeaders, safeJSON } from './streaming';
 import { castToError, getPlatformProperties, parseBody } from './utils';
 import { VERSION } from './version';
-fetch;
 const defaultHttpAgent: Agent = new KeepAliveAgent({
   keepAlive: true,
   timeout: 5 * 60 * 1000,
 });
+
+// Add this helper function at the top level
+function getFetch(): Fetch {
+  if (typeof window !== 'undefined' && window.fetch) {
+    return window.fetch.bind(window);
+  }
+  if (typeof global !== 'undefined' && global.fetch) {
+    return global.fetch;
+  }
+  if (typeof fetch !== 'undefined') {
+    return fetch;
+  }
+  throw new Error('Fetch is not available in this environment');
+}
+
 export type Fetch = (url: string, init?: RequestInit) => Promise<Response>;
 
 export type HTTPMethod = 'post' | 'get' | 'put' | 'delete';
@@ -209,7 +223,7 @@ export abstract class ApiClient {
       ...rest,
     });
     this.portkeyHeaders = this.defaultHeaders();
-    this.fetch = fetch;
+    this.fetch = getFetch();
     this.responseHeaders = {};
   }
 
@@ -295,21 +309,17 @@ export abstract class ApiClient {
       ...this.defaultHeaders(),
       ...this.customHeaders,
     };
-    const httpAgent: Agent | undefined = defaultHttpAgent;
-    let req: RequestInit;
-    if (method === 'get') {
-      req = {
-        method,
-        headers: reqHeaders,
-        ...(httpAgent && { agent: httpAgent }),
-      };
-    } else {
-      req = {
-        method,
-        body: JSON.stringify(parseBody(body)),
-        headers: reqHeaders,
-        ...(httpAgent && { agent: httpAgent }),
-      };
+
+    const agentConfig = typeof window === 'undefined' ? { agent: defaultHttpAgent } : {};
+  
+    const req: RequestInit = {
+      method,
+      headers: reqHeaders,
+      ...agentConfig,
+    };
+
+    if (method !== 'get' && body !== undefined) {
+      req.body = JSON.stringify(parseBody(body));
     }
     return { req: req, url: url.toString() };
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@ import { ApiClientInterface } from './_types/generalTypes';
 import * as API from './apis';
 import { PostBodyParams, PostResponse } from './apis/postMethod';
 import { ApiClient, APIPromise, RequestOptions } from './baseClient';
+import { isRunningInBrowser } from './core';
 import { Stream } from './streaming';
 import { readEnv, setApiKey, setBaseURL } from './utils';
 
@@ -38,6 +39,7 @@ export class Portkey extends ApiClient {
   anthropicBeta?: string | null | undefined;
   anthropicVersion?: string | null | undefined;
   mistralFimCompletion?: string | null | undefined;
+  dangerouslyAllowBrowser?: boolean | null | undefined;
   constructor({
     apiKey = readEnv('PORTKEY_API_KEY') ?? null,
     baseURL = readEnv('PORTKEY_BASE_URL') ?? null,
@@ -71,8 +73,14 @@ export class Portkey extends ApiClient {
     anthropicBeta,
     anthropicVersion,
     mistralFimCompletion,
+    dangerouslyAllowBrowser,
     ...rest
   }: ApiClientInterface) {
+    if (isRunningInBrowser() && !dangerouslyAllowBrowser) {
+      throw new Error(
+        "It looks like you're running in a browser-like environment.\n\nThis is disabled by default, as it risks exposing your secret API credentials to attackers.\nIf you understand the risks and have appropriate mitigations in place,\nyou can set the `dangerouslyAllowBrowser` option to `true`, e.g.,\n\nnew Portkey({ ..., dangerouslyAllowBrowser: true, ... });"
+      );
+    }
     super({
       apiKey,
       baseURL,
@@ -106,6 +114,7 @@ export class Portkey extends ApiClient {
       anthropicBeta,
       anthropicVersion,
       mistralFimCompletion,
+      dangerouslyAllowBrowser,
       ...rest,
     });
     this.baseURL = setBaseURL(baseURL, apiKey);
@@ -139,6 +148,7 @@ export class Portkey extends ApiClient {
     this.anthropicBeta = anthropicBeta;
     this.anthropicVersion = anthropicVersion;
     this.mistralFimCompletion = mistralFimCompletion;
+    this.dangerouslyAllowBrowser = dangerouslyAllowBrowser ?? false;
   }
 
   completions: API.Completions = new API.Completions(this);

--- a/src/core.ts
+++ b/src/core.ts
@@ -48,3 +48,14 @@ export function getBrowserInfo(): BrowserInfo | null {
 
   return null;
 }
+
+export const isRunningInBrowser = () => {
+  return (
+    // @ts-ignore
+    typeof window !== 'undefined' &&
+    // @ts-ignore
+    typeof window.document !== 'undefined' &&
+    // @ts-ignore
+    typeof navigator !== 'undefined'
+  );
+};

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,50 @@
+type Browser = 'ie' | 'edge' | 'chrome' | 'firefox' | 'safari';
+
+type BrowserInfo = {
+  browser: Browser;
+  version: string;
+};
+
+export function getBrowserInfo(): BrowserInfo | null {
+  if (typeof navigator === 'undefined' || !navigator) {
+    return null;
+  }
+
+  // NOTE: The order matters here!
+  const browserPatterns = [
+    { key: 'edge' as const, pattern: /Edge(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/ },
+    { key: 'ie' as const, pattern: /MSIE(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/ },
+    {
+      key: 'ie' as const,
+      // eslint-disable-next-line no-useless-escape
+      pattern: /Trident(?:.*rv\:(\d+)\.(\d+)(?:\.(\d+))?)?/,
+    },
+    {
+      key: 'chrome' as const,
+      pattern: /Chrome(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/,
+    },
+    {
+      key: 'firefox' as const,
+      pattern: /Firefox(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/,
+    },
+    {
+      key: 'safari' as const,
+      pattern:
+        /(?:Version\W+(\d+)\.(\d+)(?:\.(\d+))?)?(?:\W+Mobile\S*)?\W+Safari/,
+    },
+  ];
+
+  // Find the FIRST matching browser
+  for (const { key, pattern } of browserPatterns) {
+    const match = pattern.exec(navigator.userAgent);
+    if (match) {
+      const major = match[1] || 0;
+      const minor = match[2] || 0;
+      const patch = match[3] || 0;
+
+      return { browser: key, version: `${major}.${minor}.${patch}` };
+    }
+  }
+
+  return null;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,6 +161,7 @@ export function initOpenAIClient(client: Portkey) {
     baseURL: client.baseURL,
     defaultHeaders: defaultHeadersBuilder(client),
     maxRetries: 0,
+    dangerouslyAllowBrowser: client.dangerouslyAllowBrowser ?? false,
   });
 }
 export function toQueryParams(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,7 @@ import { VirtualKeysListParams } from './apis/virtualKeys';
 import { ApiKeysListParams } from './apis/apiKeys';
 import { CongfigsListParams } from './apis/configs';
 import { LogsExportListParams } from './apis/logsExport';
+import { getBrowserInfo } from './core';
 
 type PlatformProperties = {
   'x-portkey-runtime'?: string;
@@ -32,6 +33,14 @@ export const getPlatformProperties = (): PlatformProperties => {
     return {
       [`${PORTKEY_HEADER_PREFIX}runtime`]: 'node',
       [`${PORTKEY_HEADER_PREFIX}runtime-version`]: process.version,
+    };
+  }
+
+  const browserInfo = getBrowserInfo();
+  if (browserInfo) {
+    return {
+      [`${PORTKEY_HEADER_PREFIX}runtime`]: `browser: ${browserInfo.browser}`,
+      [`${PORTKEY_HEADER_PREFIX}runtime-version`]: browserInfo.version,
     };
   }
   return {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,7 +163,7 @@ export function initOpenAIClient(client: Portkey) {
     maxRetries: 0,
     dangerouslyAllowBrowser: client.dangerouslyAllowBrowser ?? false,
     fetch: async (url: RequestInfo, init?: RequestInit): Promise<Response> => {
-      // For adding duplex option only when body is a Readable stream
+      // NOTE: For adding duplex option only when body is a Readable stream
       const fetchOptions: RequestInit = {
         ...init,
         ...(init?.body &&


### PR DESCRIPTION
**Title:** Getting fetch as per environment

**Description:**
- Made change on getting the fetch as per the SDK running environment 
- Passing Agent as per the environment 


**Motivation:**
Issue reported by user

**Related Issues:**
Fixes: #168


**TBD**
Shall we add browser specific request headers as well? 