### PR TITLE
Request Type

### DIFF
--- a/src/apis/audio.ts
+++ b/src/apis/audio.ts
@@ -22,11 +22,11 @@ export class Audio extends ApiResource {
 
 export class transcriptions extends ApiResource {
   async create(
-    _body: TranscriptionCreateParams,
+    _body: TranscriptionCreateBody,
     params?: ApiClientInterface,
     opts?: RequestOptions
   ): Promise<any> {
-    const body: TranscriptionCreateParams = _body;
+    const body: TranscriptionCreateBody = _body;
     if (params) {
       const config = overrideConfig(this.client.config, params.config);
       this.client.customHeaders = {
@@ -44,11 +44,11 @@ export class transcriptions extends ApiResource {
 
 export class translations extends ApiResource {
   async create(
-    _body: TranslationCreateParams,
+    _body: TranslationCreateBody,
     params?: ApiClientInterface,
     opts?: RequestOptions
   ): Promise<any> {
-    const body: TranslationCreateParams = _body;
+    const body: TranslationCreateBody = _body;
     if (params) {
       const config = overrideConfig(this.client.config, params.config);
       this.client.customHeaders = {
@@ -66,11 +66,11 @@ export class translations extends ApiResource {
 
 export class speech extends ApiResource {
   async create(
-    _body: SpeechCreateParams,
+    _body: SpeechCreateBody,
     params?: ApiClientInterface,
     opts?: RequestOptions
   ): Promise<any> {
-    const body: SpeechCreateParams = _body;
+    const body: SpeechCreateBody = _body;
     if (params) {
       const config = overrideConfig(this.client.config, params.config);
       this.client.customHeaders = {
@@ -82,4 +82,16 @@ export class speech extends ApiResource {
     const response = await OAIclient.audio.speech.create(body, opts);
     return response;
   }
+}
+
+export interface TranscriptionCreateBody extends TranscriptionCreateParams {
+  [key: string]: any;
+}
+
+export interface TranslationCreateBody extends TranslationCreateParams {
+  [key: string]: any;
+}
+
+export interface SpeechCreateBody extends SpeechCreateParams {
+  [key: string]: any;
 }

--- a/src/apis/batches.ts
+++ b/src/apis/batches.ts
@@ -7,11 +7,11 @@ import { createHeaders } from './createHeaders';
 
 export class Batches extends ApiResource {
   async create(
-    _body: BatchCreateParams,
+    _body: BatchCreateBody,
     params?: ApiClientInterface,
     opts?: RequestOptions
   ): Promise<any> {
-    const body: BatchCreateParams = _body;
+    const body: BatchCreateBody = _body;
     if (params) {
       const config = overrideConfig(this.client.config, params.config);
       this.client.customHeaders = {
@@ -105,4 +105,8 @@ export class Batches extends ApiResource {
     const response = this.getMethod<any>(`/batches/${batchId}/output`, opts);
     return response;
   }
+}
+
+export interface BatchCreateBody extends BatchCreateParams {
+  [key: string]: any;
 }

--- a/src/apis/fineTuning.ts
+++ b/src/apis/fineTuning.ts
@@ -26,11 +26,11 @@ export class Jobs extends ApiResource {
   }
 
   async create(
-    _body: JobCreateParams,
+    _body: JobCreateBody,
     params?: ApiClientInterface,
     opts?: RequestOptions
   ): Promise<any> {
-    const body: JobCreateParams = _body;
+    const body: JobCreateBody = _body;
     if (params) {
       const config = overrideConfig(this.client.config, params.config);
       this.client.customHeaders = {
@@ -160,4 +160,13 @@ export class Checkpoints extends ApiResource {
       .withResponse();
     return finalResponse(result);
   }
+}
+
+export interface JobCreateBody extends JobCreateParams {
+  role_arn: string;
+  job_name: string;
+  output_file: string;
+  provider_options: Record<string, any>;
+  portkey_options: Record<string, any>;
+  [key: string]: any;
 }

--- a/src/apis/realtime.ts
+++ b/src/apis/realtime.ts
@@ -15,11 +15,11 @@ export class Realtime extends ApiResource {
 
 export class Sessions extends ApiResource {
   async create(
-    _body: SessionCreateParams,
+    _body: SessionCreateBody,
     params?: ApiClientInterface,
     opts?: RequestOptions
   ): Promise<any> {
-    const body: SessionCreateParams = _body;
+    const body: SessionCreateBody = _body;
     if (params) {
       const config = overrideConfig(this.client.config, params.config);
       this.client.customHeaders = {
@@ -35,4 +35,8 @@ export class Sessions extends ApiResource {
 
     return finalResponse(result);
   }
+}
+
+export interface SessionCreateBody extends SessionCreateParams {
+  [key: string]: any;
 }


### PR DESCRIPTION
**Title:** Support extra parameters in the body 

**Description:**
- Added provision for the `[key: string]: any;` in the request body interfaces

**Motivation:**
To support the all the providers request types

**Related Issues:**
Closes: #189 