### PR TITLE
Headers for Finetune

### DIFF
--- a/src/_types/generalTypes.ts
+++ b/src/_types/generalTypes.ts
@@ -34,6 +34,12 @@ export interface ApiClientInterface {
   anthropicVersion?: string | null | undefined;
   mistralFimCompletion?: string | null | undefined;
   dangerouslyAllowBrowser?: boolean | null | undefined;
+  vertexStorageBucketName?: string | null | undefined;
+  providerFileName?: string | null | undefined;
+  providerModel?: string | null | undefined;
+  awsS3Bucket?: string | null | undefined;
+  awsS3ObjectKey?: string | null | undefined;
+  awsBedrockModel?: string | null | undefined;
   [key: string]: any;
 }
 

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -187,6 +187,12 @@ export abstract class ApiClient {
     anthropicVersion,
     mistralFimCompletion,
     dangerouslyAllowBrowser,
+    vertexStorageBucketName,
+    providerFileName,
+    providerModel,
+    awsS3Bucket,
+    awsS3ObjectKey,
+    awsBedrockModel,
     ...rest
   }: ApiClientInterface) {
     this.apiKey = apiKey ?? '';
@@ -224,6 +230,12 @@ export abstract class ApiClient {
       mistralFimCompletion,
       anthropicBeta,
       dangerouslyAllowBrowser,
+      vertexStorageBucketName,
+      providerFileName,
+      providerModel,
+      awsS3Bucket,
+      awsS3ObjectKey,
+      awsBedrockModel,
       ...rest,
     });
     this.portkeyHeaders = this.defaultHeaders();

--- a/src/client.ts
+++ b/src/client.ts
@@ -40,6 +40,12 @@ export class Portkey extends ApiClient {
   anthropicVersion?: string | null | undefined;
   mistralFimCompletion?: string | null | undefined;
   dangerouslyAllowBrowser?: boolean | null | undefined;
+  vertexStorageBucketName?: string | null | undefined;
+  providerFileName?: string | null | undefined;
+  providerModel?: string | null | undefined;
+  awsS3Bucket?: string | null | undefined;
+  awsS3ObjectKey?: string | null | undefined;
+  awsBedrockModel?: string | null | undefined;
   constructor({
     apiKey = readEnv('PORTKEY_API_KEY') ?? null,
     baseURL = readEnv('PORTKEY_BASE_URL') ?? null,
@@ -74,6 +80,12 @@ export class Portkey extends ApiClient {
     anthropicVersion,
     mistralFimCompletion,
     dangerouslyAllowBrowser,
+    vertexStorageBucketName,
+    providerFileName,
+    providerModel,
+    awsS3Bucket,
+    awsS3ObjectKey,
+    awsBedrockModel,
     ...rest
   }: ApiClientInterface) {
     if (isRunningInBrowser() && !dangerouslyAllowBrowser) {
@@ -115,6 +127,12 @@ export class Portkey extends ApiClient {
       anthropicVersion,
       mistralFimCompletion,
       dangerouslyAllowBrowser,
+      vertexStorageBucketName,
+      providerFileName,
+      providerModel,
+      awsS3Bucket,
+      awsS3ObjectKey,
+      awsBedrockModel,
       ...rest,
     });
     this.baseURL = setBaseURL(baseURL, apiKey);
@@ -149,6 +167,12 @@ export class Portkey extends ApiClient {
     this.anthropicVersion = anthropicVersion;
     this.mistralFimCompletion = mistralFimCompletion;
     this.dangerouslyAllowBrowser = dangerouslyAllowBrowser ?? false;
+    this.vertexStorageBucketName = vertexStorageBucketName;
+    this.providerFileName = providerFileName;
+    this.providerModel = providerModel;
+    this.awsS3Bucket = awsS3Bucket;
+    this.awsS3ObjectKey = awsS3ObjectKey;
+    this.awsBedrockModel = awsBedrockModel;
   }
 
   completions: API.Completions = new API.Completions(this);


### PR DESCRIPTION
**Title:** Headers needed for finetune

**Description:**
Support for: 
```
x-portkey-vertex-storage-bucket-name
x-portkey-provider-file-name
x-portkey-provider-model
x-portkey-aws-s3-bucket
x-portkey-aws-s3-object-key
x-portkey-aws-bedrock-model
```


**Related Issues:**
Closes: #191 