### PR TITLE
Types: Chat Completion

### DIFF
--- a/src/_types/chatCompletionTypes.ts
+++ b/src/_types/chatCompletionTypes.ts
@@ -1,0 +1,23 @@
+import {
+  ChatCompletionResponse,
+  Choices,
+  Message,
+  Usage,
+  Logprobs,
+  ChatCompletionListResponse,
+} from '../apis/chatCompletions';
+import {
+  ChatCompletionMessageToolCall,
+  ChatCompletionTokenLogprob,
+} from 'openai/resources/chat/completions';
+
+export {
+  type ChatCompletionResponse as ChatCompletion,
+  type Choices as ChatCompletionChoices,
+  type Message as ChatCompletionMessage,
+  type Usage as ChatCompletionUsage,
+  type Logprobs as ChatCompletionLogprobs,
+  type ChatCompletionMessageToolCall as ChatCompletionMessageToolCall,
+  type ChatCompletionTokenLogprob as ChatCompletionTokenLogprob,
+  type ChatCompletionListResponse as ChatCompletionListResponse,
+};

--- a/src/_types/index.ts
+++ b/src/_types/index.ts
@@ -1,0 +1,1 @@
+export * as ChatCompletionTypes from './chatCompletionTypes';

--- a/src/apis/chatCompletions.ts
+++ b/src/apis/chatCompletions.ts
@@ -187,14 +187,14 @@ export type ChatCompletionCreateParams =
   | ChatCompletionsBodyNonStreaming
   | ChatCompletionsBodyStreaming;
 
-interface Usage {
+export interface Usage {
   prompt_tokens?: number;
   completion_tokens?: number;
   total_tokens?: number;
   [key: string]: any;
 }
 
-interface Message {
+export interface Message {
   role: string;
   content: string | Array<any>;
   refusal?: string;
@@ -210,7 +210,7 @@ export interface Logprobs {
   [key: string]: any;
 }
 
-interface Choices {
+export interface Choices {
   index?: number;
   message?: Message;
   delta?: Message;
@@ -219,7 +219,19 @@ interface Choices {
   [key: string]: any;
 }
 
-interface ChatCompletion extends APIResponseType {
+export interface ChatCompletion extends APIResponseType {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: Array<Choices>;
+  usage: Usage;
+  service_tier?: string;
+  system_fingerprint?: string;
+  [key: string]: any;
+}
+
+export interface ChatCompletionResponse {
   id: string;
   object: string;
   created: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ export import Portkey = client.Portkey;
 export import PORTKEY_GATEWAY_URL = consts.PORTKEY_GATEWAY_URL;
 export import createHeaders = apis.createHeaders;
 export { PortkeyAIRealtimeWS };
-export * as types from './_types/index';
+export * as types from './_types';
 
 export default Portkey;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export import Portkey = client.Portkey;
 export import PORTKEY_GATEWAY_URL = consts.PORTKEY_GATEWAY_URL;
 export import createHeaders = apis.createHeaders;
 export { PortkeyAIRealtimeWS };
+export * as types from './_types/index';
 
 export default Portkey;


### PR DESCRIPTION
**Title:** Types: Chat Completion

**Description:**
- added types folder for chat completion
- export types in the index file

can be imported using: `import { types } from 'portkey-ai';` 


**Related Issues:**
Closes: #198 