### PR TITLE
FIX: Prompt Render Response Type

### DIFF
--- a/src/apis/generations.ts
+++ b/src/apis/generations.ts
@@ -58,7 +58,7 @@ export interface Tool {
 }
 
 export interface Messages {
-  content?: string;
+  content?: string | any[];
   role?: string;
 }
 


### PR DESCRIPTION
**Title:** Prompt Render Response Type

**Description:**
- Prompt Render messages content can be string or Array of any

**Motivation:**
User reported issue

**Related Issues:**
Fixes: #257 