### PR TITLE
Headers check for FormData

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,6 +173,19 @@ export function initOpenAIClient(client: Portkey) {
           typeof (init.body as any)?.pipe === 'function' && { duplex: 'half' }),
       };
 
+      if (
+        fetchOptions.body &&
+        fetchOptions.body.constructor?.name === 'FormData'
+      ) {
+        if (fetchOptions.headers instanceof Headers) {
+          fetchOptions.headers.delete('Content-Type');
+        } else if (
+          fetchOptions.headers &&
+          'Content-Type' in fetchOptions.headers
+        ) {
+          delete (fetchOptions.headers as any)['Content-Type'];
+        }
+      }
       let isRetrying = false;
       let response: Response | undefined;
       try {
@@ -193,6 +206,43 @@ export function initOpenAIClient(client: Portkey) {
     },
   });
 }
+
+// export function initOpenAIClient(client: Portkey) {
+//   return new OpenAI({
+//     apiKey: client.apiKey || readEnv("OPENAI_API_KEY") || OPEN_AI_API_KEY,
+//     baseURL: client.baseURL,
+//     defaultHeaders: defaultHeadersBuilder(client),
+//     maxRetries: 0,
+//     dangerouslyAllowBrowser: client.dangerouslyAllowBrowser ?? false,
+
+//     fetch: async (url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+//       // 🧠 If body is FormData, ensure we remove any forced JSON header
+//       if (init?.body && init.body.constructor?.name === "FormData") {
+//         if (init.headers instanceof Headers) {
+//           init.headers.delete("Content-Type");
+//         } else if (init.headers && "Content-Type" in init.headers) {
+//           delete (init.headers as any)["Content-Type"];
+//         }
+//       }
+
+//       let response: Response | undefined;
+//       let shouldRetry = false;
+
+//       try {
+//         response = await fetch(url, init);
+//       } catch {
+//         shouldRetry = true;
+//       }
+
+//       if (shouldRetry || (response && !response.ok && client._shouldRetry(response))) {
+//         return await fetch(url, init);
+//       }
+
+//       if (response) return response;
+//       throw castToError(response);
+//     },
+//   });
+// }
 
 export function toQueryParams(
   params?:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,43 +207,6 @@ export function initOpenAIClient(client: Portkey) {
   });
 }
 
-// export function initOpenAIClient(client: Portkey) {
-//   return new OpenAI({
-//     apiKey: client.apiKey || readEnv("OPENAI_API_KEY") || OPEN_AI_API_KEY,
-//     baseURL: client.baseURL,
-//     defaultHeaders: defaultHeadersBuilder(client),
-//     maxRetries: 0,
-//     dangerouslyAllowBrowser: client.dangerouslyAllowBrowser ?? false,
-
-//     fetch: async (url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-//       // 🧠 If body is FormData, ensure we remove any forced JSON header
-//       if (init?.body && init.body.constructor?.name === "FormData") {
-//         if (init.headers instanceof Headers) {
-//           init.headers.delete("Content-Type");
-//         } else if (init.headers && "Content-Type" in init.headers) {
-//           delete (init.headers as any)["Content-Type"];
-//         }
-//       }
-
-//       let response: Response | undefined;
-//       let shouldRetry = false;
-
-//       try {
-//         response = await fetch(url, init);
-//       } catch {
-//         shouldRetry = true;
-//       }
-
-//       if (shouldRetry || (response && !response.ok && client._shouldRetry(response))) {
-//         return await fetch(url, init);
-//       }
-
-//       if (response) return response;
-//       throw castToError(response);
-//     },
-//   });
-// }
-
 export function toQueryParams(
   params?:
     | UsersListParams

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,9 +181,11 @@ export function initOpenAIClient(client: Portkey) {
           fetchOptions.headers.delete('Content-Type');
         } else if (
           fetchOptions.headers &&
-          'Content-Type' in fetchOptions.headers
+          'Content-Type' in fetchOptions.headers &&
+          typeof fetchOptions.headers === 'object'
         ) {
-          delete (fetchOptions.headers as any)['Content-Type'];
+          const headers = fetchOptions.headers as Record<string, any>;
+          delete headers['Content-Type'];
         }
       }
       let isRetrying = false;


### PR DESCRIPTION
**Title:** Headers check for FormData

**Description:**
- check for FormData, if present then remove content-type from default headers being set

**Motivation:**
Issue in using translation and transcription endpoints

**Related Issues:**
Fixes: #271 